### PR TITLE
Explicitly import Base operators

### DIFF
--- a/src/PowerSeries.jl
+++ b/src/PowerSeries.jl
@@ -1,6 +1,6 @@
 module PowerSeries
 
-import Base: convert, sqrt, exp, log, sin, cos, tan, asin, acos, atan, sinh, cosh, tanh, asinh, acosh, atanh, csc, sec, cot, acsc, asec, acot, csch, sech, coth, acsch, asech, acoth, gamma, polygamma, floor, ceil, round, sign, abs, <
+import Base: convert, sqrt, exp, log, sin, cos, tan, asin, acos, atan, sinh, cosh, tanh, asinh, acosh, atanh, csc, sec, cot, acsc, asec, acot, csch, sech, coth, acsch, asech, acoth, gamma, polygamma, floor, ceil, round, sign, abs, <, /, *, ^, +, -
 
 abstract AbstractSeries{T<:Real, N} <: Number
 


### PR DESCRIPTION
This fixes a deprecation made recently in Julia master, https://github.com/JuliaLang/julia/pull/12235